### PR TITLE
useCallbackでhandleRouterPushを囲んで、毎回同じ関数オブジェクトを返す

### DIFF
--- a/esm/useRouterPrefetch.js
+++ b/esm/useRouterPrefetch.js
@@ -1,13 +1,13 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { prepareUrlAs } from "./lib/prepareUrlAs";
 export function useRouterPrefetch(url, observe, nextRouterOptions) {
     if (observe === void 0) { observe = true; }
     var router = useRouter();
-    var handleRouterPush = function (event) {
+    var handleRouterPush = useCallback(function (event) {
         event === null || event === void 0 ? void 0 : event.preventDefault();
         router.push(url, nextRouterOptions === null || nextRouterOptions === void 0 ? void 0 : nextRouterOptions.as, nextRouterOptions === null || nextRouterOptions === void 0 ? void 0 : nextRouterOptions.options);
-    };
+    }, []);
     var prefetchTarget = useRef(null);
     var prefetchLink = function () {
         if (typeof url === "string") {

--- a/lib/useRouterPrefetch.js
+++ b/lib/useRouterPrefetch.js
@@ -7,10 +7,10 @@ var prepareUrlAs_1 = require("./lib/prepareUrlAs");
 function useRouterPrefetch(url, observe, nextRouterOptions) {
     if (observe === void 0) { observe = true; }
     var router = router_1.useRouter();
-    var handleRouterPush = function (event) {
+    var handleRouterPush = react_1.useCallback(function (event) {
         event === null || event === void 0 ? void 0 : event.preventDefault();
         router.push(url, nextRouterOptions === null || nextRouterOptions === void 0 ? void 0 : nextRouterOptions.as, nextRouterOptions === null || nextRouterOptions === void 0 ? void 0 : nextRouterOptions.options);
-    };
+    }, []);
     var prefetchTarget = react_1.useRef(null);
     var prefetchLink = function () {
         if (typeof url === "string") {

--- a/src/useRouterPrefetch.ts
+++ b/src/useRouterPrefetch.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { prepareUrlAs } from "./lib/prepareUrlAs";
 
@@ -46,10 +46,13 @@ export function useRouterPrefetch<T extends Element>(
 ) {
   const router = useRouter();
 
-  const handleRouterPush = (event?: SyntheticEvent<Element, Event>) => {
-    event?.preventDefault();
-    router.push(url, nextRouterOptions?.as, nextRouterOptions?.options);
-  };
+  const handleRouterPush = useCallback(
+    (event?: SyntheticEvent<Element, Event>) => {
+      event?.preventDefault();
+      router.push(url, nextRouterOptions?.as, nextRouterOptions?.options);
+    },
+    []
+  );
 
   const prefetchTarget = useRef<T | null>(null);
   const prefetchLink = () => {


### PR DESCRIPTION
Fixes #2 